### PR TITLE
fix!: Update command line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,24 +12,29 @@ pip install iddiff
 
 ## Usage
 ```
-usage: iddiff [-h] [-t] [-c] [-l LINES] [-w] [-s] [--version] file1 file2
+usage: iddiff [-h] [--side-by-side | -w] [-t] [-c CONTEXT_LINES] [-s]
+              [--version]
+              file1 file2
 
 Internet-Draft diff tool
 
 positional arguments:
-  file1
-  file2
+  file1                 first file to compare
+  file2                 second file to compare
 
 optional arguments:
   -h, --help            show this help message and exit
-  -t, --table           produce a HTML table (default)
-  -c, --context         produce a context (default)
-  -l LINES, --lines LINES
-                        set number of context lines (default 8)
+  --side-by-side        side by side difference (default)
   -w, --wdiff           produce word difference
-  -s, --skip-whitespaces
-                        skip multilines with only whitespaces
+  -s, --skip-whitespace
+                        skip multilines with only whitespace
   --version             show program's version number and exit
+
+side by side options:
+  -t, --table-only      produce only a HTML table
+  -c CONTEXT_LINES, --context-lines CONTEXT_LINES
+                        set number of context lines (set to 0 for no context)
+                        (default 8)
 ```
 
 ## Tests

--- a/iddiff/iddiff.py
+++ b/iddiff/iddiff.py
@@ -94,13 +94,13 @@ CONTEXT_LINE = """
       </tr>
       <tr id="context-{context}">
         <td></td>
-        <th class="change">
+        <th class="change" scope="col">
           <a href="#context-{context}">
            <small>Skipping</small>
           </a>
         </th>
         <td></td>
-        <th class="change">
+        <th class="change" scope="col">
           <a href="#context-{context}">
            <small>Skipping</small>
           </a>

--- a/iddiff/iddiff.py
+++ b/iddiff/iddiff.py
@@ -107,7 +107,7 @@ CONTEXT_LINE = """
         </th>
       </tr>"""
 
-WHITESPACES = ''.join([
+WHITESPACE = ''.join([
     whitespace,  # python stirng.whitespace
     '\u0009',    # character tabulation
     '\u000A',    # line feed
@@ -142,16 +142,16 @@ WHITESPACES = ''.join([
     '\uFEFF'])   # zero width non-breaking space
 
 
-def cleanup(lines, skip_whitespaces):
+def cleanup(lines, skip_whitespace):
     '''Removes skippable content, shrinks multiple empty lines
-    If a link only contains WHITESPACES,
-    that line will get stripped of any WHITESPACES.'''
+    If a link only contains WHITESPACE,
+    that line will get stripped of any WHITESPACE.'''
 
     id_lines = []
-    if skip_whitespaces:
+    if skip_whitespace:
         previous_blank = False
         for line in lines:
-            if len(line.strip(WHITESPACES)) > 0:
+            if len(line.strip(WHITESPACE)) > 0:
                 previous_blank = False
                 keep = True
                 for skip in SKIPS:
@@ -161,7 +161,7 @@ def cleanup(lines, skip_whitespaces):
                 if keep:
                     id_lines.append(line)
             elif not previous_blank:
-                id_lines.append(line.strip(WHITESPACES))
+                id_lines.append(line.strip(WHITESPACE))
                 previous_blank = True
     else:
         for line in lines:
@@ -177,7 +177,7 @@ def cleanup(lines, skip_whitespaces):
 
 def add_span(line, css_class):
     '''Add span tag with the class'''
-    stripped_line = line.strip('\0+-^\1').strip(WHITESPACES)
+    stripped_line = line.strip('\0+-^\1').strip(WHITESPACE)
     if len(stripped_line) == 0:
         return ''
     else:
@@ -244,7 +244,7 @@ def get_html_table(filename1, filename2, rows):
 
 
 def get_iddiff(file1, file2, context_lines=None, table_only=False,
-               wdiff=False, skip_whitespaces=False):
+               wdiff=False, skip_whitespace=False):
     '''Return iddiff output'''
 
     title = 'Diff: {file1} - {file2}'.format(
@@ -253,18 +253,18 @@ def get_iddiff(file1, file2, context_lines=None, table_only=False,
 
     if wdiff:
         with open(file1, 'r') as file:
-            id_a_lines = ''.join(cleanup(file.readlines(), skip_whitespaces))
+            id_a_lines = ''.join(cleanup(file.readlines(), skip_whitespace))
         with open(file2, 'r') as file:
-            id_b_lines = ''.join(cleanup(file.readlines(), skip_whitespaces))
+            id_b_lines = ''.join(cleanup(file.readlines(), skip_whitespace))
 
         output = get_wdiff(id_a_lines, id_b_lines)
 
         output = HTML.format(output=output, title=title)
     else:
         with open(file1, 'r') as file:
-            id_a_lines = cleanup(file.readlines(), skip_whitespaces)
+            id_a_lines = cleanup(file.readlines(), skip_whitespace)
         with open(file2, 'r') as file:
-            id_b_lines = cleanup(file.readlines(), skip_whitespaces)
+            id_b_lines = cleanup(file.readlines(), skip_whitespace)
 
         rows = get_diff_rows(id_a_lines, id_b_lines, context_lines)
 
@@ -279,21 +279,39 @@ def get_iddiff(file1, file2, context_lines=None, table_only=False,
 def parse_args(args=None):
     '''Parse command line arguments and return options'''
     parser = ArgumentParser(description='Internet-Draft diff tool')
-    parser.add_argument('-t', '--table', action='store_true', default=False,
-                        help='produce a HTML table (default)')
-    parser.add_argument('-c', '--context', action='store_true', default=False,
-                        help='produce a context (default)')
-    parser.add_argument('-l', '--lines', type=int, default=8,
-                        help='set number of context lines (default 8)')
-    parser.add_argument('-w', '--wdiff', action='store_true', default=False,
-                        help='produce word difference')
-    parser.add_argument('-s', '--skip-whitespaces', action='store_true',
+
+    main_group = parser.add_mutually_exclusive_group()
+    main_group.add_argument('--side-by-side',
+                            action='store_true',
+                            default=True,
+                            help='side by side difference (default)')
+    main_group.add_argument('-w', '--wdiff',
+                            action='store_true',
+                            default=False,
+                            help='produce word difference')
+
+    group = parser.add_argument_group('side by side options')
+    group.add_argument('-t', '--table-only',
+                       action='store_true',
+                       default=False,
+                       help='produce only a HTML table')
+    group.add_argument('-c', '--context-lines',
+                       type=int,
+                       default=8,
+                       help='set number of context lines (set to 0 for no '
+                            'context) (default 8)')
+
+    parser.add_argument('-s', '--skip-whitespace',
+                        action='store_true',
                         default=False,
-                        help='skip multilines with only whitespaces')
-    parser.add_argument('file1')
-    parser.add_argument('file2')
-    parser.add_argument('--version', action='version',
+                        help='skip multilines with only whitespace')
+    parser.add_argument('--version',
+                        action='version',
                         version='iddiff {}'.format(VERSION))
+
+    parser.add_argument('file1', help='first file to compare')
+    parser.add_argument('file2', help='second file to compare')
+
     return parser.parse_args(args)
 
 
@@ -302,18 +320,18 @@ def main():
 
     file1 = options.file1
     file2 = options.file2
-    if options.context:
-        context_lines = options.lines
-    else:
+    if options.context_lines == 0:
         context_lines = None
+    else:
+        context_lines = options.context_lines
 
     try:
         iddiff = get_iddiff(file1=file1,
                             file2=file2,
                             context_lines=context_lines,
-                            table_only=options.table,
+                            table_only=options.table_only,
                             wdiff=options.wdiff,
-                            skip_whitespaces=options.skip_whitespaces)
+                            skip_whitespace=options.skip_whitespace)
         stdout.writelines(iddiff)
     except FileNotFoundError as e:
         stderr.write('iddiff: {}.\n'.format(e))

--- a/tests/test_iddiff.py
+++ b/tests/test_iddiff.py
@@ -38,7 +38,7 @@ class TestIddiff(TestCase):
     def test_cleanup_shrink_empty_lines(self):
         lines = [' ', '', '\u0009', '\u2009\u200A ']
 
-        output = cleanup(lines, skip_whitespaces=True)
+        output = cleanup(lines, skip_whitespace=True)
 
         self.assertEqual(len(output), 1)
         self.assertEqual(output[0], '')
@@ -46,15 +46,15 @@ class TestIddiff(TestCase):
     def test_cleanup_keep_empty_lines(self):
         lines = [' ', '', '\u0009', '\u2009\u200A ']
 
-        output = cleanup(lines, skip_whitespaces=False)
+        output = cleanup(lines, skip_whitespace=False)
 
         self.assertEqual(len(output), 4)
         for line in lines:
             self.assertIn(line, output)
 
     def test_cleanup_skippable_content(self):
-        for skip_whitespaces in (True, False):
-            output = cleanup(HEADERS_AND_FOOTERS, skip_whitespaces)
+        for skip_whitespace in (True, False):
+            output = cleanup(HEADERS_AND_FOOTERS, skip_whitespace)
 
             self.assertEqual(len(output), 0)
 
@@ -65,9 +65,9 @@ class TestIddiff(TestCase):
             'aliqua. Ut enim ad minim veniam, quis nostrud exercitation  ',
             'ullamco laboris nisi ut aliquip ex ea commodo consequat.    ']
 
-        for skip_whitespaces in (True, False):
+        for skip_whitespace in (True, False):
             output = cleanup(HEADERS_AND_FOOTERS + non_skippable,
-                             skip_whitespaces)
+                             skip_whitespace)
 
             self.assertEqual(len(output), len(non_skippable))
 
@@ -150,22 +150,16 @@ class TestIddiff(TestCase):
         self.assertIn(LINES_A[0], table)
 
     def test_arg_parse_table(self):
-        self.assertFalse(parse_args(DEFAULT_ARGS).table)
+        self.assertFalse(parse_args(DEFAULT_ARGS).table_only)
 
-        for arg in ['-t', '--table']:
-            self.assertTrue(parse_args(DEFAULT_ARGS + [arg, ]).table)
-
-    def test_arg_parse_context(self):
-        self.assertFalse(parse_args(DEFAULT_ARGS).context)
-
-        for arg in ['-c', '--context']:
-            self.assertTrue(parse_args(DEFAULT_ARGS + [arg, ]).context)
+        for arg in ['-t', '--table-only']:
+            self.assertTrue(parse_args(DEFAULT_ARGS + [arg, ]).table_only)
 
     def test_arg_parse_lines(self):
-        self.assertEqual(parse_args(DEFAULT_ARGS).lines, 8)
+        self.assertEqual(parse_args(DEFAULT_ARGS).context_lines, 8)
 
-        for args in [['-l', '10'], ['--lines', '10']]:
-            self.assertEqual(parse_args(DEFAULT_ARGS + args).lines, 10)
+        for args in [['-c', '10'], ['--context-lines', '10']]:
+            self.assertEqual(parse_args(DEFAULT_ARGS + args).context_lines, 10)
 
     def test_arg_parse_files(self):
         options = parse_args(DEFAULT_ARGS)
@@ -222,7 +216,7 @@ class TestIddiff(TestCase):
 
         self.assertIn('<html', output.getvalue())
         self.assertIn('<table', output.getvalue())
-        self.assertNotIn('>Skipping<', output.getvalue())
+        self.assertIn('>Skipping<', output.getvalue())
         self.assertTrue(output.getvalue().strip().endswith('</html>'))
 
     def test_main_table_only(self):
@@ -232,19 +226,19 @@ class TestIddiff(TestCase):
             main()
 
         self.assertNotIn('<html', output.getvalue())
-        self.assertNotIn('>Skipping<', output.getvalue())
+        self.assertIn('>Skipping<', output.getvalue())
         self.assertTrue(output.getvalue().strip().startswith('<table'))
         self.assertTrue(output.getvalue().strip().endswith('</table>'))
 
-    def test_main_with_context(self):
-        sys.argv = [basename(__file__), '-c', FILE_1, FILE_2]
+    def test_main_with_without_context(self):
+        sys.argv = [basename(__file__), '-c', 0, FILE_1, FILE_2]
         output = StringIO()
         with patch('sys.stdout.writelines', new=output.writelines):
             main()
 
         self.assertIn('<html', output.getvalue())
         self.assertIn('<table', output.getvalue())
-        self.assertIn('>Skipping<', output.getvalue())
+        self.assertNotIn('>Skipping<', output.getvalue())
         self.assertTrue(output.getvalue().strip().endswith('</html>'))
 
     def test_main_file_error(self):


### PR DESCRIPTION
Fixes #16

Updated commandline options:
```
usage: iddiff [-h] [--side-by-side | -w] [-t] [-c CONTEXT_LINES] [-s]
              [--version]
              file1 file2

Internet-Draft diff tool

positional arguments:
  file1                 first file to compare
  file2                 second file to compare

optional arguments:
  -h, --help            show this help message and exit
  --side-by-side        side by side difference (default)
  -w, --wdiff           produce word difference
  -s, --skip-whitespace
                        skip multilines with only whitespace
  --version             show program's version number and exit

side by side options:
  -t, --table-only      produce only a HTML table
  -c CONTEXT_LINES, --context-lines CONTEXT_LINES
                        set number of context lines (set to 0 for no context)
                        (default 8)
```